### PR TITLE
Addded python PIL module to enable local img resizing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - &
 # Python App Engine component
 RUN apt-get install -y google-cloud-sdk-app-engine-python google-cloud-sdk-app-engine-python-extras google-cloud-sdk-datastore-emulator
 
+# Additianal python modules
+RUN apt-get install -y python-pil
+
 # cleanup build tools to save image footprint
 RUN apt-get remove -y curl apt-transport-https && \
     apt-get autoremove -y && \

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ This container is auto-built on [docker hub]
 [GAE Atuin]: https://github.com/atuinframework/gae-atuin
 [Google Cloud SDK]: https://cloud.google.com/sdk/
 [atuin-tools]: https://github.com/atuinframework/atuin-tools
-[docker hub]: https://hub.docker.com/r/atuinframework/atuin-tools/
+[docker hub]: https://hub.docker.com/r/atuinframework/gae-atuin-devenv/


### PR DESCRIPTION
Installation of the PIL python module during docker image build.

Warning shown in the `dev_appserver.py` logs:
```bash
devenv_1  | WARNING  2018-11-16 11:03:46,924 blob_image.py:208] Serving resized images requires a working Python "PIL" module. The image is served without resizing.
```